### PR TITLE
build!: require rustc 1.85

### DIFF
--- a/.github/workflows/rust-minimal.yml
+++ b/.github/workflows/rust-minimal.yml
@@ -55,7 +55,7 @@ jobs:
         use-ros2-testing: ${{ matrix.ros_distribution == 'rolling' }}
 
     - name: Setup Rust
-      uses: dtolnay/rust-toolchain@1.75
+      uses: dtolnay/rust-toolchain@1.85
       with:
         components: clippy, rustfmt
 

--- a/rosidl_runtime_rs/Cargo.toml
+++ b/rosidl_runtime_rs/Cargo.toml
@@ -19,7 +19,7 @@ serde = { version = "1", optional = true }
 
 [features]
 default = []
-# This feature is solely for the purpose of being able to generate documetation without a ROS installation
+# This feature is solely for the purpose of being able to generate documentation without a ROS installation
 # The only intended usage of this feature is for docs.rs builders to work, and is not intended to be used by end users
 use_ros_shim = []
 

--- a/rosidl_runtime_rs/src/sequence.rs
+++ b/rosidl_runtime_rs/src/sequence.rs
@@ -503,7 +503,7 @@ impl std::error::Error for SequenceExceedsBoundsError {}
 macro_rules! impl_sequence_alloc_for_primitive_type {
     ($rust_type:ty, $init_func:ident, $fini_func:ident, $copy_func:ident) => {
         #[link(name = "rosidl_runtime_c")]
-        extern "C" {
+        unsafe extern "C" {
             fn $init_func(seq: *mut Sequence<$rust_type>, size: usize) -> bool;
             fn $fini_func(seq: *mut Sequence<$rust_type>);
             fn $copy_func(

--- a/rosidl_runtime_rs/src/string.rs
+++ b/rosidl_runtime_rs/src/string.rs
@@ -116,7 +116,7 @@ pub struct StringExceedsBoundsError {
 macro_rules! string_impl {
     ($string:ty, $char_type:ty, $unsigned_char_type:ty, $string_conversion_func:ident, $init:ident, $fini:ident, $assignn:ident, $sequence_init:ident, $sequence_fini:ident, $sequence_copy:ident) => {
         #[link(name = "rosidl_runtime_c")]
-        extern "C" {
+        unsafe extern "C" {
             fn $init(s: *mut $string) -> bool;
             fn $fini(s: *mut $string);
             fn $assignn(s: *mut $string, value: *const $char_type, n: usize) -> bool;

--- a/rosidl_runtime_rs/src/traits.rs
+++ b/rosidl_runtime_rs/src/traits.rs
@@ -215,7 +215,9 @@ pub trait Action: 'static {
     /// Split a feedback message into its two parts:
     /// * The UUID of the goal that the feedback is for
     /// * The message the describes the feedback data
-    fn split_feedback_message(feedback: RmwFeedbackMessage<Self>) -> ([u8; 16], RmwFeedbackData<Self>);
+    fn split_feedback_message(
+        feedback: RmwFeedbackMessage<Self>,
+    ) -> ([u8; 16], RmwFeedbackData<Self>);
 
     /// Create a result request message with the given goal ID.
     fn create_result_request(goal_id: &[u8; 16]) -> RmwResultRequest<Self>;


### PR DESCRIPTION
This PR updates the requirement for the rustc compiler to 1.85.